### PR TITLE
Fix handling controller 0

### DIFF
--- a/perc-status
+++ b/perc-status
@@ -265,7 +265,7 @@ omr = subprocess.Popen([options.omreport, 'storage', 'controller', '-fmt', 'xml'
 stdout, ignored = omr.communicate()
 root = ET.fromstring(stdout)
 for obj in root.find('Controllers').findall('DCStorageObject'):
-    if options.controller:
+    if options.controller is not None:
         if options.controller == get_field(obj, 'ControllerNum'):
             Controller(obj, controllers)
     else:


### PR DESCRIPTION
`0` tests as false in python.
To check if an option (with no default) is set or not, better check against `None`

As it stands `perc-status -c 0` will print info about all controllers
